### PR TITLE
Enable ansible source

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -7,8 +7,8 @@ import { filter } from 'fuzzaldrin';
 export default class Provider {
   constructor() {
     let self = this;
-    self.selector = '.source.yaml';
-    self.disableForSelector = '.source.yaml .comment';
+    self.selector = '.source.yaml, .source.ansible';
+    self.disableForSelector = '.source.yaml .comment, .source.ansible .comment';
     self.modules = [];
     self.directives = [];
     self.loop_directives = [];


### PR DESCRIPTION
Enable autocompletion for people using the [language-ansible](https://atom.io/packages/language-ansible) package.
