### PR TITLE
Revert "make compatible with ansible language package"

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -7,8 +7,8 @@ import { filter } from 'fuzzaldrin';
 export default class Provider {
   constructor() {
     let self = this;
-    self.selector = '.source.yaml', '.source.ansible';
-    self.disableForSelector = '.source.yaml .comment', '.source.ansible .comment';
+    self.selector = '.source.yaml';
+    self.disableForSelector = '.source.yaml .comment';
     self.modules = [];
     self.directives = [];
     self.loop_directives = [];


### PR DESCRIPTION
Reverts h-hirokawa/atom-autocomplete-ansible#6
