### PR TITLE
Fix issues #31 and #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ An [autocomplete+](https://github.com/atom/autocomplete-plus) provider for Ansib
 or
 * Ansible >= 2.4 and Python >= 3.5
 
-:warning: With Ansible 2.5, you must also install [boto3](https://pypi.python.org/pypi/boto3) and [botocore](https://pypi.python.org/pypi/botocore) (see [#32](https://github.com/h-hirokawa/atom-autocomplete-ansible/issues/32)).
-
 ## ToDo
 * Autocompletion of module arguments when the cursor is in module block.
 * Autocompletion of variables/factors.

--- a/libs/parse_ansible.py
+++ b/libs/parse_ansible.py
@@ -85,8 +85,8 @@ def main():
                 local_action.append(name)
     result['directives']['with_'] = ['Task']
 
-    for lookup in lookup_loader.all():
-        name = os.path.splitext(os.path.basename(lookup._original_path))[0]
+    for lookup in lookup_loader.all(path_only=True):
+        name = os.path.splitext(os.path.basename(lookup))[0]
         result['lookup_plugins'].append(name)
 
     print(json.dumps(result))

--- a/libs/provider.js
+++ b/libs/provider.js
@@ -43,8 +43,6 @@ export default class Provider {
         if (err) {
           const no_ansible_match = err.message.match(
             /No module named ['"]?ansible/),
-            miss_modules_match = err.message.match(
-              /ansible.errors.AnsibleError: .+ requires (.+)\./);
           if (no_ansible_match) {
             window.atom.notifications.addWarning(
               'autocomplete-ansible unable to import ansible.', {
@@ -55,14 +53,6 @@ command and then reload the editor.
 ${interpreter} -m pip install ansible
 \`\`\`
 `,
-                dismissable: true
-              }
-            );
-          } else if (miss_modules_match) {
-            window.atom.notifications.addWarning(
-              `autocomplete-ansible unable to import ${miss_modules_match[1]}.`, {
-                description: `Install ${miss_modules_match[1]} with
-\`${interpreter} -m pip\`.`,
                 dismissable: true
               }
             );

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,4 @@ deps =
   ansible23: ansible>=2.3,<2.4
   ansible24: ansible>=2.4,<2.5
   ansible25: ansible>=2.5,<2.6
-  ansible25: boto3
-  ansible25: botocore
 commands = pytest {posargs}


### PR DESCRIPTION
Do not try to load lookup plugins, just retrieve the list.
This way, no need to install the dependencies of all the lookup plugins.