### PR TITLE
Fix JS syntax error from PR #36

### DIFF
--- a/libs/provider.js
+++ b/libs/provider.js
@@ -42,7 +42,7 @@ export default class Provider {
         self._loading = false;
         if (err) {
           const no_ansible_match = err.message.match(
-            /No module named ['"]?ansible/),
+            /No module named ['"]?ansible/);
           if (no_ansible_match) {
             window.atom.notifications.addWarning(
               'autocomplete-ansible unable to import ansible.', {


### PR DESCRIPTION
I was too fast in my JS edition:

```
SyntaxError: /home/alex/.atom/packages/autocomplete-ansible/libs/provider.js: Unexpected token (46:10)
          const no_ansible_match = err.message.match(
            /No module named ['"]?ansible/),
          if (no_ansible_match) {
            window.atom.notifications.addWarning(
              'autocomplete-ansible unable to import ansible.', {
                description: `You must install ansible with the following
    at Parser.pp.raise (/usr/share/atom/resources/app.asar/node_modules/babylon/lib/parser/location.js:24:13)
```