### PR TITLE
Update tests for current Ansible and Python versions (2019-12-16)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,29 +4,26 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 env:
-  - ANSIBLE=2.4
-  - ANSIBLE=2.5
-  - ANSIBLE=2.6
   - ANSIBLE=2.7
+  - ANSIBLE=2.8
+  - ANSIBLE=2.9
 matrix:
   include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env: ANSIBLE=2.4
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env: ANSIBLE=2.5
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env: ANSIBLE=2.6
-    - python: 3.7
+    - python: 3.8
       dist: xenial
       sudo: true
       env: ANSIBLE=2.7
+    - python: 3.8
+      dist: xenial
+      sudo: true
+      env: ANSIBLE=2.8
+    - python: 3.8
+      dist: xenial
+      sudo: true
+      env: ANSIBLE=2.9
   fast_finish: true
 install: pip install tox-travis
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,19 @@
 [tox]
 envlist =
-  py{27,35,36,37}-ansible{24,25,26,27}
+  py{27,35,36,37,38}-ansible{27,28,29}
 skipsdist = True
 
 [travis:env]
 ANSIBLE =
-    2.4: ansible24
-    2.5: ansible25
-    2.6: ansible26
     2.7: ansible27
+    2.8: ansible28
+    2.9: ansible29
 
 [testenv]
 setenv = ANSIBLE_DEPRECATION_WARNINGS = False
 deps =
   pytest
-  ansible24: ansible>=2.4,<2.5
-  ansible25: ansible>=2.5,<2.6
-  ansible26: ansible>=2.6,<2.7
-  ansible27: ansible>=2.7dev,<2.8
+  ansible27: ansible>=2.7,<2.8
+  ansible28: ansible>=2.8,<2.9
+  ansible29: ansible>=2.9,<2.10
 commands = pytest {posargs}


### PR DESCRIPTION
* Add testing with Python 3.8 (could probably add 3.9 as well)
* Add testing with Ansible 2.8.x and 2.9.x
* Remove testing with Ansible < 2.7

Signed-off-by: Drew Northup <drew.northup@maine.edu>