### PR TITLE
ansible 2.10.* DocCLI.find_plugins fix

### DIFF
--- a/libs/parse_ansible.py
+++ b/libs/parse_ansible.py
@@ -41,7 +41,10 @@ def get_module_list():
         if use_old_loader:
             doc_cli.find_modules(path)
         else:
-            founds = doc_cli.find_plugins(path, 'module')
+            try:
+                founds = doc_cli.find_plugins(path, 'module')
+            except TypeError:
+                founds = doc_cli.find_plugins(path, 'plugins', 'module')
             if founds:
                 doc_cli.plugin_list.update(founds)
     module_list = (

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "autocomplete-ansible",
   "main": "./libs/main",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "An autocomplete+ provider for Ansible Playbook",
   "keywords": [],
   "repository": "https://github.com/h-hirokawa/atom-autocomplete-ansible",


### PR DESCRIPTION
Enables support of Ansible 2.10.x by detecting the TypeError exception
which results from trying to call the find_plugins() function with the
number of arguments that was valid in 2.9.x.

This is a very minor cleanup of @ebenezar-mccoy 's code from #54 