### PR TITLE
CI: Ansible 2.10, Ubuntu Bionic, Cruft removal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+os: linux
+dist: xenial
 language: python
 python:
   - "2.7"
@@ -10,20 +11,21 @@ env:
   - ANSIBLE=2.7
   - ANSIBLE=2.8
   - ANSIBLE=2.9
+  - ANSIBLE=2.10
 matrix:
   include:
     - python: 3.8
-      dist: xenial
-      sudo: true
+      dist: bionic
       env: ANSIBLE=2.7
     - python: 3.8
-      dist: xenial
-      sudo: true
+      dist: bionic
       env: ANSIBLE=2.8
     - python: 3.8
-      dist: xenial
-      sudo: true
+      dist: bionic
       env: ANSIBLE=2.9
+    - python: 3.8
+      dist: bionic
+      env: ANSIBLE=2.10
   fast_finish: true
 install: pip install tox-travis
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{27,35,36,37,38}-ansible{27,28,29}
+  py{27,35,36,37,38}-ansible{27,28,29,210}
 skipsdist = True
 
 [travis:env]
@@ -8,6 +8,7 @@ ANSIBLE =
     2.7: ansible27
     2.8: ansible28
     2.9: ansible29
+    2.10: ansible210
 
 [testenv]
 setenv = ANSIBLE_DEPRECATION_WARNINGS = False
@@ -16,4 +17,5 @@ deps =
   ansible27: ansible>=2.7,<2.8
   ansible28: ansible>=2.8,<2.9
   ansible29: ansible>=2.9,<2.10
+  ansible210: ansible>=2.10,<2.11
 commands = pytest {posargs}


### PR DESCRIPTION
* Add testing with Ansible 2.10
* Add testing with Ubuntu Bionic
* Fixup tests to remove cruft
  * Removing duplicated Xenial tests. (Travis currently is using that
    as the default.)
  * Remove sudo, it doesn't do anything anymore
  * Set the default OS & Dist to facilitate future sanity

Signed-off-by: Drew Northup <drew.northup@maine.edu>