### PR TITLE
Second to last travis org update (local)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 python:
   - "2.7"
   - "3.5"
-  - "3.6"
   - "3.7"
   - "3.8"
 env:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{27,35,36,37,38}-ansible{27,28,29,210}
+  py{27,35,37,38}-ansible{27,28,29,210,211}
 skipsdist = True
 
 [travis:env]

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ ANSIBLE =
 [testenv]
 setenv = ANSIBLE_DEPRECATION_WARNINGS = False
 deps =
+  setuptools_rust
+  wheel
   pytest
   ansible27: ansible>=2.7,<2.8
   ansible28: ansible>=2.8,<2.9


### PR DESCRIPTION
After attempting to fix a testing problem with Python 3.6, disable testing with it altogether. Versions of Ansible 2.12 and beyond won't support it anyway.